### PR TITLE
#168815457 builds delete office endpoint

### DIFF
--- a/app/api/v1/models/Office.py
+++ b/app/api/v1/models/Office.py
@@ -38,3 +38,22 @@ class Office:
         """ 
         the_office = [office for office in OFFICE if office['id']==id]
         return the_office
+    
+    def delete_office(id):
+        """
+        This method deletes an office whose id matches with the id that
+         the user has supplied.
+        On success it returns a success message that the office has been
+         deleted 
+        Or not found on successive calls to the endpoint 
+        Or when the office has not been found from the word go
+        """
+        the_office = Office.get_office(id)
+        if the_office:
+            for office in OFFICE:
+                if office["id"]==id:
+                    OFFICE.remove(office)
+                    # the dynamic nature of python allows me to return a string at this point
+                    # normally the_office would be a list or an empty list
+                    the_office = "Office deleted successfully."
+        return the_office

--- a/app/api/v1/views/Office.py
+++ b/app/api/v1/views/Office.py
@@ -46,3 +46,12 @@ def get_office(id):
     """
     office = Office.get_office(id)
     return check_return(office,"Office")
+
+
+@version_one.route('/offices/<int:id>',methods=['DELETE'])
+def remove_office(id):
+    """This deletes an office if found  and returns a success message
+    Or a faliure message if no office has been found and On successive hits 
+    to this endpoint after the first successive hit """
+    is_deleted = Office.delete_office(id)
+    return check_return(is_deleted,"Office")

--- a/tests/v1/test_office_views.py
+++ b/tests/v1/test_office_views.py
@@ -57,7 +57,7 @@ class TestOfficeViews(unittest.TestCase):
 
     def test_getting_all_offices(self):
         """Test getting all offices """
-        #self.post()
+        self.post()
         response = self.client.get('api/v1/offices')
         self.assertEqual(response.status_code,200)
         result = json.loads(response.data.decode('utf-8'))
@@ -71,3 +71,16 @@ class TestOfficeViews(unittest.TestCase):
         result = json.loads(response.data.decode('utf-8'))
         self.assertEqual(result["Data"], [self.specific_office])
         self.assertEqual(result["Status"],200)
+
+    def test_getting_a_non_existent_office(self):
+        """Test getting a non-existent office"""
+        response = self.client.get('api/v1/offices/{}'.format(20))
+        self.assertEqual(response.status_code,404)
+
+
+    def test_deleting_office(self):
+        """ Test deletion of an office """
+        # delete may or may not have a body so in this case it does not 
+        # hence no content type header
+        response = self.client.delete('api/v1/offices/{}'.format(0))
+        self.assertEqual(response.status_code,200)


### PR DESCRIPTION
#### What does this PR do?
Finishes delete office endpoint
#### Description of Task to be completed?
adds tests for deleting office
DELETE /api/v1/offices/{id} endpoint is working
#### How should this be manually tested?
once you clone this repo to your local machine cd into the directory do a $/>  python run.py 
then open the endpoint on postman as shown below on the screenshots below

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168815457
#### Screenshots (if appropriate)
![apiDeleteExisting](https://user-images.githubusercontent.com/49396576/65798040-5f705300-e179-11e9-9183-6ed4d0d81c6b.JPG)
![apiDeleteNonExisting](https://user-images.githubusercontent.com/49396576/65798041-6008e980-e179-11e9-84ac-43e30e5aee33.JPG)
