### PR TITLE
#168821331 builds get specific party endpoint 

### DIFF
--- a/app/api/v1/models/Party.py
+++ b/app/api/v1/models/Party.py
@@ -27,5 +27,17 @@ class Party:
         """This will return all the parties in the given list 
         Or an empty list if no parties exist"""      
         return PARTY
+    
+    def get_party(id):
+        """
+        This will return a specific party object given the id
+        supplied by the user Or an empty list if no party was found.
+        This method will also be re-used by the methods that need 
+        to know if an party exists before making any
+        changes to it that is modify and delete
+        """
+        # this is a list comprehension to make code readable
+        the_party = [party for party in PARTY if party["id"] == id]
+        return the_party
 
     

--- a/app/api/v1/views/Party.py
+++ b/app/api/v1/views/Party.py
@@ -38,3 +38,13 @@ def all_parties():
     # existing_parties is a list of the parties found/not
     existing_parties = Party.get_parties()
     return check_return(existing_parties,"Party")
+
+@version_one.route('parties/<int:id>', methods=['GET'])
+def get_party(id):
+    """
+    This gets a specific party whose id matches with the one 
+    supplied by the user or a not found message if no party matches 
+    with the id supplied by the user
+    """
+    party = Party.get_party(id)
+    return check_return(party,"Party")

--- a/tests/v1/test_party_views.py
+++ b/tests/v1/test_party_views.py
@@ -56,4 +56,13 @@ class TestPartyViews(unittest.TestCase):
         result = json.loads(response.data.decode('utf-8'))
         self.assertEqual(result["Data"], [self.specific_party])
         self.assertEqual(result["Status"], 200)
+
+    
+    def test_getting_specific_party(self):
+        """Test getting a specific party"""
+        response = self.client.get('api/v1/parties/{}'.format(0))
+        self.assertEqual(response.status_code,200)
+        result = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(result["Data"], [self.specific_party])
+        self.assertEqual(result["Status"], 200)
         


### PR DESCRIPTION
#### What does this PR do?
Builds get specific party endpoint
#### Description of Task to be completed?
adds tests for getting specific party
/api/v1/parties/{id} is finished and working
#### How should this be manually tested?
Once you clone this repo cd into the directory do a $/> python run.py to fire the application then
open postman and go the urls as shown in the screenshot below
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168821331
#### Screenshots (if appropriate)
![apiGetSpecificPartyNull](https://user-images.githubusercontent.com/49396576/66147816-41db3780-e618-11e9-901d-32fae167f68a.JPG)
![apiGetSpecificParty](https://user-images.githubusercontent.com/49396576/66147814-40117400-e618-11e9-8b8e-3bf67c8b77e0.JPG)
